### PR TITLE
The `bin` script was started without the node executable

### DIFF
--- a/bookcase.js
+++ b/bookcase.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const path = require('path');
 const { fromCallback } = require('./libs/utils');


### PR DESCRIPTION
E.g. `npm install -g tw-bookcase ; tw-bookcase --version` showed this error message on Windows:

```
/.../tw-bookcase: line 1: /node_modules/tw-bookcase/bookcase.js: No such file or directory
```

See https://docs.npmjs.com/files/package.json#bin